### PR TITLE
Require Craft 3 RC1+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,9 @@
     "issues": "https://github.com/enupal/backup/issues",
     "docs": "https://enupal.com/en/craft-plugins/enupal-backup/docs"
   },
+  "require": {
+    "craftcms/cms": "^3.0.0-RC1"
+  },
   "extra": {
     "name": "Enupal Backup",
     "handle": "enupal-backup",


### PR DESCRIPTION
The Plugin Store is eventually going to require that plugins define their Craft CMS compatibility, via the `require` property in composer.json.